### PR TITLE
Re-send to label only on sensitive metadata changes

### DIFF
--- a/src/domain/business-rules/computePublishStatus.rules.spec.ts
+++ b/src/domain/business-rules/computePublishStatus.rules.spec.ts
@@ -29,9 +29,24 @@ describe('computePublishStatus', () => {
       expect(givenDecision.publishStatus).toEqual(expectedPublishStatus)
     })
 
+    it('when labelStatus is done', async () => {
+      // GIVEN
+      const givenDecision = {
+        ...mockUtils.decisionModel,
+        labelStatus: LabelStatus.DONE
+      }
+      const expectedPublishStatus = PublishStatus.TOBEPUBLISHED
+
+      // WHEN
+      givenDecision.publishStatus = computePublishStatus(givenDecision)
+
+      // THEN
+      expect(givenDecision.publishStatus).toEqual(expectedPublishStatus)
+    })
+
     Object.keys(LabelStatus).forEach((labelStatusKey) => {
       const labelStatusValue = LabelStatus[labelStatusKey as keyof typeof LabelStatus]
-      if (labelStatusValue !== LabelStatus.TOBETREATED) {
+      if (labelStatusValue !== LabelStatus.TOBETREATED && labelStatusValue !== LabelStatus.DONE) {
         it(`when labelStatus is ${labelStatusValue}`, async () => {
           // GIVEN
           const givenDecision = {

--- a/src/domain/business-rules/computePublishStatus.rules.ts
+++ b/src/domain/business-rules/computePublishStatus.rules.ts
@@ -13,7 +13,8 @@ export function computePublishStatus(decisionDto: CreateDecisionDTO): PublishSta
   logger.log({ ...formatLogs })
 
   const publishStatus =
-    decisionDto.labelStatus === LabelStatus.TOBETREATED
+    decisionDto.labelStatus === LabelStatus.TOBETREATED ||
+    decisionDto.labelStatus === LabelStatus.DONE
       ? PublishStatus.TOBEPUBLISHED
       : PublishStatus.BLOCKED
 

--- a/src/domain/business-rules/isDecisionHasSensitiveChanges.rules.ts
+++ b/src/domain/business-rules/isDecisionHasSensitiveChanges.rules.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash'
 import { LogsFormat } from '../../infrastructure/utils/logsFormat.utils'
 import { CreateDecisionDTO } from '../../infrastructure/dto/createDecision.dto'
 import { Logger } from '@nestjs/common'
@@ -18,17 +19,24 @@ export function isDecisionHasSensitiveChanges(
   if (currentDecision.originalText != newDecision.originalText) {
     logger.log({
       ...formatLogs,
-      msg: `Decision ${newDecision.sourceName}:${newDecision.sourceId} has a sensitive change on originalText.`
+      msg: `Decision has a sensitive change on originalText.`,
+      data: { decision: { sourceId: currentDecision.sourceId, sourceName: newDecision.sourceName } }
     })
     return true
   }
-  if (currentDecision.occultation != newDecision.occultation) {
+  if (!isEqual(currentDecision.occultation, newDecision.occultation)) {
     logger.log({
       ...formatLogs,
-      msg: `Decision ${newDecision.sourceName}:${newDecision.sourceId} has a sensitive change on occultation.`
+      msg: `Decision has a sensitive change on occultation.`,
+      data: { decision: { sourceId: currentDecision.sourceId, sourceName: newDecision.sourceName } }
     })
     return true
   }
+  logger.log({
+    ...formatLogs,
+    msg: `Decision has no sensitive changes, bypassing label`,
+    data: { decision: { sourceId: currentDecision.sourceId, sourceName: newDecision.sourceName } }
+  })
 
   return false
 }

--- a/src/domain/business-rules/isDecisionHasSensitiveChanges.rules.ts
+++ b/src/domain/business-rules/isDecisionHasSensitiveChanges.rules.ts
@@ -1,0 +1,34 @@
+import { LogsFormat } from '../../infrastructure/utils/logsFormat.utils'
+import { CreateDecisionDTO } from '../../infrastructure/dto/createDecision.dto'
+import { Logger } from '@nestjs/common'
+import { Decision } from 'src/infrastructure/db/models/decision.model'
+
+const logger = new Logger()
+const formatLogs: LogsFormat = {
+  operationName: 'isDecisionHasSensitiveChanges',
+  msg: `isDecisionHasSensitiveChanges is starting`
+}
+
+export function isDecisionHasSensitiveChanges(
+  currentDecision: Decision,
+  newDecision: CreateDecisionDTO
+): boolean {
+  logger.log({ ...formatLogs })
+
+  if (currentDecision.originalText != newDecision.originalText) {
+    logger.log({
+      ...formatLogs,
+      msg: `Decision ${newDecision.sourceName}:${newDecision.sourceId} has a sensitive change on originalText.`
+    })
+    return true
+  }
+  if (currentDecision.occultation != newDecision.occultation) {
+    logger.log({
+      ...formatLogs,
+      msg: `Decision ${newDecision.sourceName}:${newDecision.sourceId} has a sensitive change on occultation.`
+    })
+    return true
+  }
+
+  return false
+}

--- a/src/domain/decisions.repository.interface.ts
+++ b/src/domain/decisions.repository.interface.ts
@@ -11,6 +11,8 @@ export interface InterfaceDecisionsRepository {
 
   getById(id: string): Promise<Decision>
 
+  getBySourceIdAndSourceName(sourceId: number, sourceName: string): Promise<Decision>
+
   updateStatut(id: string, status: string): Promise<string>
 
   updateDecisionPseudonymisee(

--- a/src/infrastructure/db/repositories/decisions.repository.ts
+++ b/src/infrastructure/db/repositories/decisions.repository.ts
@@ -100,6 +100,16 @@ export class DecisionsRepository implements InterfaceDecisionsRepository {
     return decision
   }
 
+  async getBySourceIdAndSourceName(sourceId: number, sourceName: string): Promise<Decision> {
+    const decision = await this.decisionModel
+      .findOne({ sourceId, sourceName })
+      .lean()
+      .catch((error) => {
+        throw new DatabaseError(error)
+      })
+    return decision
+  }
+
   async removeById(id: string): Promise<void> {
     const removalResponse = await this.decisionModel
       .deleteOne({ _id: new Types.ObjectId(id) })

--- a/src/usecase/createDecision.usecase.ts
+++ b/src/usecase/createDecision.usecase.ts
@@ -43,7 +43,11 @@ export class CreateDecisionUsecase {
         decision.sourceId,
         decision.sourceName
       )
-      if (currentDecision && currentDecision.publishStatus === PublishStatus.SUCCESS) {
+      if (
+        currentDecision &&
+        currentDecision.publishStatus === PublishStatus.SUCCESS &&
+        currentDecision.labelStatus === LabelStatus.EXPORTED
+      ) {
         decision.labelStatus = isDecisionHasSensitiveChanges(currentDecision, decision)
           ? decision.labelStatus
           : LabelStatus.DONE


### PR DESCRIPTION
C'est un essai visant a réduire le nombre de décisions étant retraitées dans label : 
Dans le cas ou on reçoit une décision que l'on a déjà en base de donnée on ne la renvoie dans label que dans le cas ou des métadonnées sensibles on évoluer (cette liste de métadonnées reste a établir)