### PR TITLE
Fix extend patchable properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",
-        "dbsder-api-types": "2.0.6",
+        "dbsder-api-types": "2.1.0",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "helmet": "^8.1.0",
@@ -2569,9 +2569,9 @@
       }
     },
     "node_modules/dbsder-api-types": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/dbsder-api-types/-/dbsder-api-types-2.0.6.tgz",
-      "integrity": "sha512-wwAs5nBJqZy1tup3eQt1oLmjU/clJvjS2iyE5wNto9n8EDL+KNq+4A4FSIrRmTr9hY9k8V4gal8N7D4fl0M2lg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dbsder-api-types/-/dbsder-api-types-2.1.0.tgz",
+      "integrity": "sha512-6zf2PqZXFC6SGcZFqKg6GqDTiP/EwW4pVr94oUeqovRxfpek+UhSMFcHzBMTrPhhwL2LPKfzcVHrLGVHWpC3ow==",
       "license": "MIT",
       "dependencies": {
         "mongodb": "^6.15.0",
@@ -8649,9 +8649,9 @@
       "dev": true
     },
     "dbsder-api-types": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/dbsder-api-types/-/dbsder-api-types-2.0.6.tgz",
-      "integrity": "sha512-wwAs5nBJqZy1tup3eQt1oLmjU/clJvjS2iyE5wNto9n8EDL+KNq+4A4FSIrRmTr9hY9k8V4gal8N7D4fl0M2lg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dbsder-api-types/-/dbsder-api-types-2.1.0.tgz",
+      "integrity": "sha512-6zf2PqZXFC6SGcZFqKg6GqDTiP/EwW4pVr94oUeqovRxfpek+UhSMFcHzBMTrPhhwL2LPKfzcVHrLGVHWpC3ow==",
       "requires": {
         "mongodb": "^6.15.0",
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^1.8.4",
-    "dbsder-api-types": "2.0.6",
+    "dbsder-api-types": "2.1.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "helmet": "^8.1.0",

--- a/src/controller/decision.ts
+++ b/src/controller/decision.ts
@@ -15,6 +15,7 @@ import {
 } from '../service/decision/handler'
 import { forbiddenError, missingValue } from '../library/error'
 import { Service } from '../service/authentication'
+import { Decision } from 'dbsder-api-types'
 
 const app = Router()
 
@@ -40,9 +41,9 @@ app.get('/decisions', async (req, res, next) => {
   }
 })
 
-function parsePatchBody(body: Request['body']): UpdatableDecisionFields {
+function parsePatchBody(sourceName: Decision["sourceName"], body: Request['body']): UpdatableDecisionFields {
   if (!body) throw missingValue('req.body', new Error('body is missing on request'))
-  return parseUpdatableDecisionFields(body)
+  return parseUpdatableDecisionFields(sourceName, body)
 }
 
 app.patch('/decisions/:id', async (req, res, next) => {
@@ -50,8 +51,9 @@ app.patch('/decisions/:id', async (req, res, next) => {
     if (req.context?.service !== Service.LABEL) throw forbiddenError(new Error())
 
     const id = parseId(req.params.id)
-    const updateFields = parsePatchBody(req.body)
-    const { _id } = await updateDecision(id, updateFields)
+    const { sourceName } = await fetchDecisionById(id)
+    const updateFields = parsePatchBody(sourceName, req.body)
+    const { _id } = await updateDecision(id, sourceName, updateFields)
     res.send({
       _id,
       message: 'Decision mise à jour'

--- a/src/controller/decision.ts
+++ b/src/controller/decision.ts
@@ -41,7 +41,10 @@ app.get('/decisions', async (req, res, next) => {
   }
 })
 
-function parsePatchBody(sourceName: Decision["sourceName"], body: Request['body']): UpdatableDecisionFields {
+function parsePatchBody(
+  sourceName: Decision['sourceName'],
+  body: Request['body']
+): UpdatableDecisionFields {
   if (!body) throw missingValue('req.body', new Error('body is missing on request'))
   return parseUpdatableDecisionFields(sourceName, body)
 }

--- a/src/controller/label.ts
+++ b/src/controller/label.ts
@@ -5,16 +5,18 @@ import {
   parseUpdatableDecisionFields,
   UpdatableDecisionFields
 } from '../service/decision/models'
-import { updateDecisionForLabel } from '../service/decision/handler'
+import { fetchDecisionById, updateDecisionForLabel } from '../service/decision/handler'
 import { Service } from '../service/authentication'
+import { Decision } from 'dbsder-api-types'
 
 const app = Router()
 
 function parseBody(
+  sourceName: Decision["sourceName"],
   body: Request['body']
 ): Omit<UpdatableDecisionFields, 'labelStatus' | 'publishStatus'> {
   if (!body) throw missingValue('req.body', new Error('body is missing on request'))
-  return parseUpdatableDecisionFields(body)
+  return parseUpdatableDecisionFields(sourceName, body)
 }
 
 /**
@@ -26,8 +28,9 @@ app.patch('/label/:id', async (req, res, next) => {
     if (req.context?.service !== Service.LABEL) throw forbiddenError(new Error())
 
     const id = parseId(req.params.id)
-    const updateFields = parseBody(req.body)
-    const { _id } = await updateDecisionForLabel(id, updateFields)
+    const { sourceName } = await fetchDecisionById(id)
+    const updateFields = parseBody(sourceName, req.body)
+    const { _id } = await updateDecisionForLabel(id, sourceName, updateFields)
     res.send({
       _id,
       message: 'Decision mise à jour'

--- a/src/controller/label.ts
+++ b/src/controller/label.ts
@@ -28,9 +28,9 @@ app.patch('/label/:id', async (req, res, next) => {
     if (req.context?.service !== Service.LABEL) throw forbiddenError(new Error())
 
     const id = parseId(req.params.id)
-    const { sourceName } = await fetchDecisionById(id)
-    const updateFields = parseBody(sourceName, req.body)
-    const { _id } = await updateDecisionForLabel(id, sourceName, updateFields)
+    const decision = await fetchDecisionById(id)
+    const updateFields = parseBody(decision.sourceName, req.body)
+    const { _id } = await updateDecisionForLabel(decision, updateFields)
     res.send({
       _id,
       message: 'Decision mise à jour'

--- a/src/library/sderDB.ts
+++ b/src/library/sderDB.ts
@@ -48,13 +48,11 @@ export const findAndReplaceDecision = safeMongoQuery(_findAndReplaceDecision)
 async function _findAndUpdateDecision(
   decisionFilters: Filter<UnIdentifiedDecision>,
   decision: Partial<UnIdentifiedDecision>
-): Promise<Decision> {
+): Promise<Decision | null> {
   const db = await dbConnect()
   const decisionWithId = await db
     .collection<UnIdentifiedDecision>('decisions')
     .findOneAndUpdate(decisionFilters, { $set: decision }, { returnDocument: 'after' })
-  if (!decisionWithId)
-    throw unexpectedError(new Error('Upsert behave like there were no document and cannot create'))
   return decisionWithId
 }
 export const findAndUpdateDecision = safeMongoQuery(_findAndUpdateDecision)

--- a/src/service/decision/handler.ts
+++ b/src/service/decision/handler.ts
@@ -103,9 +103,13 @@ export async function saveDecision(decision: UnIdentifiedDecisionSupported): Pro
 
 export async function updateDecision(
   targetId: Decision['_id'],
+  sourceName: Decision['sourceName'],
   updateFields: UpdatableDecisionFields
-) {
-  return findAndUpdateDecision({ _id: targetId }, updateFields)
+): Promise<Decision> {
+  const filter = { _id: targetId, sourceName }
+  const decision = await findAndUpdateDecision(filter, updateFields)
+  if (!decision) throw notFound("Decision", new Error(`Decision missing for id: ${filter._id} and sourceName: ${filter.sourceName}`))
+  return decision
 }
 
 export async function fetchDecisionById(decisionId: Decision['_id']): Promise<Decision> {

--- a/src/service/decision/handler.ts
+++ b/src/service/decision/handler.ts
@@ -108,7 +108,11 @@ export async function updateDecision(
 ): Promise<Decision> {
   const filter = { _id: targetId, sourceName }
   const decision = await findAndUpdateDecision(filter, updateFields)
-  if (!decision) throw notFound("Decision", new Error(`Decision missing for id: ${filter._id} and sourceName: ${filter.sourceName}`))
+  if (!decision)
+    throw notFound(
+      'Decision',
+      new Error(`Decision missing for id: ${filter._id} and sourceName: ${filter.sourceName}`)
+    )
   return decision
 }
 

--- a/src/service/decision/models.ts
+++ b/src/service/decision/models.ts
@@ -132,7 +132,18 @@ export function parseDecisionListFilters(x: unknown): DecisionListFilters {
   return filter
 }
 
-export type UpdatableDecisionFields = Partial<Omit<UnIdentifiedDecision, 'originalText' | 'public' | 'debatPublic' | 'occultation' | 'NACCode' | 'endCaseCode' | 'blocOccultation'>>
+export type UpdatableDecisionFields = Partial<
+  Omit<
+    UnIdentifiedDecision,
+    | 'originalText'
+    | 'public'
+    | 'debatPublic'
+    | 'occultation'
+    | 'NACCode'
+    | 'endCaseCode'
+    | 'blocOccultation'
+  >
+>
 
 export function parseUpdatableDecisionFields(x: unknown): UpdatableDecisionFields {
   if (typeof x !== 'object' || !x) throw notSupported('filters', x, new Error())
@@ -159,7 +170,8 @@ export function parseUpdatableDecisionFields(x: unknown): UpdatableDecisionField
   }
 
   if ('pseudoText' in x) {
-    if (typeof x.pseudoText !== 'string') throw notSupported('pseudoText', x.pseudoText, new Error())
+    if (typeof x.pseudoText !== 'string')
+      throw notSupported('pseudoText', x.pseudoText, new Error())
   }
 
   if ('labelTreatments' in x) {

--- a/src/service/decision/models.ts
+++ b/src/service/decision/models.ts
@@ -132,19 +132,15 @@ export function parseDecisionListFilters(x: unknown): DecisionListFilters {
   return filter
 }
 
-export type UpdatableDecisionFields = {
-  labelStatus?: LabelStatus
-  publishStatus?: PublishStatus
-  pseudoText?: string
-  labelTreatments?: LabelTreatments
-}
+export type UpdatableDecisionFields = Partial<Omit<UnIdentifiedDecision, 'originalText' | 'public' | 'debatPublic' | 'occultation' | 'NACCode' | 'endCaseCode' | 'blocOccultation'>>
+
 export function parseUpdatableDecisionFields(x: unknown): UpdatableDecisionFields {
   if (typeof x !== 'object' || !x) throw notSupported('filters', x, new Error())
-  let updateDecision: UpdatableDecisionFields = {}
+  let updateDecision: UpdatableDecisionFields = x
 
   if ('publishStatus' in x) {
     try {
-      updateDecision = { ...updateDecision, publishStatus: parsePublishStatus(x.publishStatus) }
+      updateDecision.publishStatus = parsePublishStatus(x.publishStatus)
     } catch (err) {
       throw err instanceof Error
         ? notSupported('publishStatus', x.publishStatus, err)
@@ -154,7 +150,7 @@ export function parseUpdatableDecisionFields(x: unknown): UpdatableDecisionField
 
   if ('labelStatus' in x) {
     try {
-      updateDecision = { ...updateDecision, labelStatus: parseLabelStatus(x.labelStatus) }
+      updateDecision.labelStatus = parseLabelStatus(x.labelStatus)
     } catch (err) {
       throw err instanceof Error
         ? notSupported('labelStatus', x.labelStatus, err)
@@ -163,17 +159,12 @@ export function parseUpdatableDecisionFields(x: unknown): UpdatableDecisionField
   }
 
   if ('pseudoText' in x) {
-    const pseudoText = x.pseudoText
-    if (typeof pseudoText !== 'string') throw notSupported('pseudoText', pseudoText, new Error())
-    updateDecision = { ...updateDecision, pseudoText }
+    if (typeof x.pseudoText !== 'string') throw notSupported('pseudoText', x.pseudoText, new Error())
   }
 
   if ('labelTreatments' in x) {
     try {
-      updateDecision = {
-        ...updateDecision,
-        labelTreatments: parseLabelTreatments(x.labelTreatments)
-      }
+      updateDecision.labelTreatments = parseLabelTreatments(x.labelTreatments)
     } catch (err) {
       throw err instanceof Error
         ? notSupported('labelTreatments', x.labelTreatments, err)

--- a/src/service/decision/models.ts
+++ b/src/service/decision/models.ts
@@ -7,10 +7,7 @@ import {
   Decision,
   parseLabelStatus,
   DecisionDila,
-  LabelStatus,
-  LabelTreatments,
   parseLabelTreatments,
-  PublishStatus,
   parsePublishStatus,
   hasSourceNameDila
 } from 'dbsder-api-types'

--- a/src/service/decision/models.ts
+++ b/src/service/decision/models.ts
@@ -132,9 +132,16 @@ export function parseDecisionListFilters(x: unknown): DecisionListFilters {
   return filter
 }
 
-const protectedKeys = ["_id", "sourceId", "sourceName"] as const
-export type UpdatableDecisionFields = Partial<DecisionTcom> | Partial<DecisionTj> | Partial<DecisionCc> | Partial<DecisionCa>
-export function parseUpdatableDecisionFields(sourceName: Decision["sourceName"], x: unknown): UpdatableDecisionFields {
+const protectedKeys = ['_id', 'sourceId', 'sourceName'] as const
+export type UpdatableDecisionFields =
+  | Partial<DecisionTcom>
+  | Partial<DecisionTj>
+  | Partial<DecisionCc>
+  | Partial<DecisionCa>
+export function parseUpdatableDecisionFields(
+  sourceName: Decision['sourceName'],
+  x: unknown
+): UpdatableDecisionFields {
   try {
     if (typeof x !== 'object' || !x) throw notSupported('decisionFields', x, new Error())
 
@@ -145,9 +152,16 @@ export function parseUpdatableDecisionFields(sourceName: Decision["sourceName"],
         new Error(`Dbsder-api doesn't handle Dila source`)
       )
 
-    const updatableDecisionFields = parsePartialDecision(sourceName, x) as Exclude<ReturnType<typeof parsePartialDecision>, Partial<DecisionDila>>
-    if (protectedKeys.some(key => Object.keys(updatableDecisionFields).includes(key)))
-      throw notSupported('updatableDecisionFields', updatableDecisionFields, new Error(`Keys: "${protectedKeys.join(", ")}" are protected and cannot be update`))
+    const updatableDecisionFields = parsePartialDecision(sourceName, x) as Exclude<
+      ReturnType<typeof parsePartialDecision>,
+      Partial<DecisionDila>
+    >
+    if (protectedKeys.some((key) => Object.keys(updatableDecisionFields).includes(key)))
+      throw notSupported(
+        'updatableDecisionFields',
+        updatableDecisionFields,
+        new Error(`Keys: "${protectedKeys.join(', ')}" are protected and cannot be update`)
+      )
 
     return updatableDecisionFields
   } catch (err) {
@@ -201,25 +215,25 @@ export function mapDecisionListFiltersIntoDbFilters(filters: DecisionListFilters
   const dateFilter =
     startDate && endDate
       ? {
-        [dateType]: {
-          $gte: startDate.toISOString(),
-          $lte: endDate.toISOString()
-        }
-      }
-      : startDate
-        ? {
           [dateType]: {
             $gte: startDate.toISOString(),
-            $lte: new Date().toISOString()
+            $lte: endDate.toISOString()
           }
         }
-        : endDate
-          ? {
+      : startDate
+        ? {
             [dateType]: {
-              $gte: new Date().toISOString(),
-              $lte: endDate.toISOString()
+              $gte: startDate.toISOString(),
+              $lte: new Date().toISOString()
             }
           }
+        : endDate
+          ? {
+              [dateType]: {
+                $gte: new Date().toISOString(),
+                $lte: endDate.toISOString()
+              }
+            }
           : {}
 
   return {

--- a/src/service/decision/rulesLabel.test.ts
+++ b/src/service/decision/rulesLabel.test.ts
@@ -11,7 +11,6 @@ import {
 } from 'dbsder-api-types/dist/types/common'
 import { UpdatableDecisionFields } from './models'
 
-const findDecision = jest.spyOn(sderDB, 'findDecision')
 const findAndUpdateDecision = jest.spyOn(sderDB, 'findAndUpdateDecision')
 
 const fakeDecision = (id: ObjectId): DecisionTj => ({
@@ -57,17 +56,18 @@ const fakeDecision = (id: ObjectId): DecisionTj => ({
 
 describe('service/decision/rulesLabel', () => {
   beforeEach(() => {
-    findDecision.mockReset()
     findAndUpdateDecision.mockReset()
   })
 
   describe('updateDecisionForLabel', () => {
     it('should throw an error if decision is not find', async () => {
-      findDecision.mockResolvedValue(null)
       const id = new ObjectId()
+      const decision = fakeDecision(id)
+
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(null))
 
       await expect(async () => {
-        await rulesLabel.updateDecisionForLabel(id, {})
+        await rulesLabel.updateDecisionForLabel(decision, {})
       }).rejects.toThrow(/not found/)
     })
 
@@ -90,11 +90,12 @@ describe('service/decision/rulesLabel', () => {
         ]
       }
 
-      findDecision.mockResolvedValue(decision)
+      // return something
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision)) 
 
-      await rulesLabel.updateDecisionForLabel(id, updateFields)
+      await rulesLabel.updateDecisionForLabel(decision, updateFields)
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id, sourceName: decision.sourceName })
       expect(findAndUpdateDecision.mock.lastCall?.[1].pseudoText).toEqual(updateFields.pseudoText)
       expect(findAndUpdateDecision.mock.lastCall?.[1].labelTreatments).toEqual(
         updateFields.labelTreatments
@@ -105,20 +106,21 @@ describe('service/decision/rulesLabel', () => {
       const firstId = new ObjectId()
       const firstDecision = { ...fakeDecision(firstId), publishStatus: PublishStatus.SUCCESS }
       const secondId = new ObjectId()
-      const secondDecision = { ...fakeDecision(firstId), publishStatus: PublishStatus.BLOCKED }
+      const secondDecision = { ...fakeDecision(secondId), publishStatus: PublishStatus.BLOCKED }
 
-      findDecision.mockResolvedValue(firstDecision)
-      await rulesLabel.updateDecisionForLabel(firstId, {})
+      // return something
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(firstDecision)) 
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: firstId })
+      await rulesLabel.updateDecisionForLabel(firstDecision, {})
+
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: firstId, sourceName: firstDecision.sourceName })
       expect(findAndUpdateDecision.mock.lastCall?.[1].publishStatus).toEqual(
         PublishStatus.TOBEPUBLISHED
       )
 
-      findDecision.mockResolvedValue(secondDecision)
-      await rulesLabel.updateDecisionForLabel(secondId, {})
+      await rulesLabel.updateDecisionForLabel(secondDecision, {})
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: secondId })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: secondId, sourceName: secondDecision.sourceName })
       expect(findAndUpdateDecision.mock.lastCall?.[1].publishStatus).toEqual(PublishStatus.BLOCKED)
     })
 
@@ -162,10 +164,12 @@ describe('service/decision/rulesLabel', () => {
         ]
       }
 
-      findDecision.mockResolvedValue(decision)
-      await rulesLabel.updateDecisionForLabel(id, updateFields)
+      // return something
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision)) 
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id })
+      await rulesLabel.updateDecisionForLabel(decision, updateFields)
+
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id, sourceName: decision.sourceName })
       expect(findAndUpdateDecision.mock.lastCall?.[1].labelTreatments).toEqual([
         {
           order: 1,
@@ -197,7 +201,6 @@ describe('service/decision/rulesLabel', () => {
   })
 
   afterAll(() => {
-    findDecision.mockRestore()
     findAndUpdateDecision.mockRestore()
   })
 })

--- a/src/service/decision/rulesLabel.test.ts
+++ b/src/service/decision/rulesLabel.test.ts
@@ -91,11 +91,14 @@ describe('service/decision/rulesLabel', () => {
       }
 
       // return something
-      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision)) 
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision))
 
       await rulesLabel.updateDecisionForLabel(decision, updateFields)
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id, sourceName: decision.sourceName })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({
+        _id: id,
+        sourceName: decision.sourceName
+      })
       expect(findAndUpdateDecision.mock.lastCall?.[1].pseudoText).toEqual(updateFields.pseudoText)
       expect(findAndUpdateDecision.mock.lastCall?.[1].labelTreatments).toEqual(
         updateFields.labelTreatments
@@ -109,18 +112,24 @@ describe('service/decision/rulesLabel', () => {
       const secondDecision = { ...fakeDecision(secondId), publishStatus: PublishStatus.BLOCKED }
 
       // return something
-      findAndUpdateDecision.mockReturnValue(Promise.resolve(firstDecision)) 
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(firstDecision))
 
       await rulesLabel.updateDecisionForLabel(firstDecision, {})
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: firstId, sourceName: firstDecision.sourceName })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({
+        _id: firstId,
+        sourceName: firstDecision.sourceName
+      })
       expect(findAndUpdateDecision.mock.lastCall?.[1].publishStatus).toEqual(
         PublishStatus.TOBEPUBLISHED
       )
 
       await rulesLabel.updateDecisionForLabel(secondDecision, {})
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: secondId, sourceName: secondDecision.sourceName })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({
+        _id: secondId,
+        sourceName: secondDecision.sourceName
+      })
       expect(findAndUpdateDecision.mock.lastCall?.[1].publishStatus).toEqual(PublishStatus.BLOCKED)
     })
 
@@ -165,11 +174,14 @@ describe('service/decision/rulesLabel', () => {
       }
 
       // return something
-      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision)) 
+      findAndUpdateDecision.mockReturnValue(Promise.resolve(decision))
 
       await rulesLabel.updateDecisionForLabel(decision, updateFields)
 
-      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({ _id: id, sourceName: decision.sourceName })
+      expect(findAndUpdateDecision.mock.lastCall?.[0]).toEqual({
+        _id: id,
+        sourceName: decision.sourceName
+      })
       expect(findAndUpdateDecision.mock.lastCall?.[1].labelTreatments).toEqual([
         {
           order: 1,

--- a/src/service/decision/rulesLabel.ts
+++ b/src/service/decision/rulesLabel.ts
@@ -18,25 +18,25 @@ export async function updateDecisionForLabel(
   const originalTreatments = originalDecision?.labelTreatments ?? []
   const updatedLabelTreatments = updateFields.labelTreatments
     ? [
-      ...originalTreatments,
-      ...updateFields.labelTreatments.map(({ order, ..._ }) => ({
-        ..._,
-        order: originalTreatments.length + order
-      }))
-    ]
+        ...originalTreatments,
+        ...updateFields.labelTreatments.map(({ order, ..._ }) => ({
+          ..._,
+          order: originalTreatments.length + order
+        }))
+      ]
     : originalTreatments
 
   const filter = { _id: originalDecision._id, sourceName: originalDecision.sourceName }
-  const decision = await findAndUpdateDecision(
-    filter,
-    {
-      pseudoText: updateFields.pseudoText,
-      labelTreatments: updatedLabelTreatments,
-      labelStatus,
-      publishStatus
-    }
-  )
+  const decision = await findAndUpdateDecision(filter, {
+    pseudoText: updateFields.pseudoText,
+    labelTreatments: updatedLabelTreatments,
+    labelStatus,
+    publishStatus
+  })
 
-  if (!decision) throw unexpectedError(new Error(`Decision found with id: "${originalDecision._id}" but not found during update`))
+  if (!decision)
+    throw unexpectedError(
+      new Error(`Decision found with id: "${originalDecision._id}" but not found during update`)
+    )
   return decision
 }

--- a/src/service/decision/rulesLabel.ts
+++ b/src/service/decision/rulesLabel.ts
@@ -7,8 +7,9 @@ import { notFound } from '../../library/error'
 
 export async function updateDecisionForLabel(
   targetId: Decision['_id'],
+  sourceName: Decision['sourceName'],
   updateFields: Omit<UpdatableDecisionFields, 'labelStatus' | 'publishStatus'>
-) {
+): Promise<Decision> {
   const originalDecision = await findDecision({
     _id: targetId
   })
@@ -31,8 +32,9 @@ export async function updateDecisionForLabel(
       ]
     : originalTreatments
 
-  return findAndUpdateDecision(
-    { _id: targetId },
+  const filter = { _id: targetId, sourceName }
+  const decision = await findAndUpdateDecision(
+    filter,
     {
       pseudoText: updateFields.pseudoText,
       labelTreatments: updatedLabelTreatments,
@@ -40,4 +42,7 @@ export async function updateDecisionForLabel(
       publishStatus
     }
   )
+
+  if (!decision) throw notFound("Decision", new Error(`Decision missing for ${JSON.stringify(filter)}`))
+  return decision
 }


### PR DESCRIPTION
Je voulais conserver le `let updateDecision: UpdatableDecisionFields = {}` et itérer sur les propriétés de `x` (en gardant la validation pour les quatre propriétés "spéciales"), mais `x` étant `unknown`, il n'est manifestement pas itérable... Pas  certain du reste, donc.